### PR TITLE
Fix controller failing when implementing billing methods other than Sisow

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -34,14 +34,13 @@ module Spree
 
     def confirm_sisow
       return unless (params[:state] == "payment") && params[:order][:payments_attributes]
-
       payment_method = PaymentMethod.find(payment_method_id_param)
+      return unless payment_method.is_a?(PaymentMethod::SisowBilling::SisowPaymentMethod)
 
       opts = return_url_opts
       if payment_method.is_a?(PaymentMethod::SisowBilling::Ideal)
         opts[:issuer_id] = params[:issuer_id]
       end
-
       redirect_to payment_method.redirect_url(@order, opts)
     end
 

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -33,9 +33,9 @@ module Spree
     end
 
     def confirm_sisow
-      return unless (params[:state] == "payment") && params[:order][:payments_attributes]
+      return unless confirm_params_valid?
       payment_method = PaymentMethod.find(payment_method_id_param)
-      return unless payment_method.is_a?(PaymentMethod::SisowBilling::SisowPaymentMethod)
+      return unless sisow_payment_method?(payment_method)
 
       opts = return_url_opts
       if payment_method.is_a?(PaymentMethod::SisowBilling::Ideal)
@@ -55,6 +55,14 @@ module Spree
 
     def payment_method_id_param
       params[:order][:payments_attributes].first[:payment_method_id]
+    end
+
+    def confirm_params_valid?
+      (params[:state] == "payment") && params[:order][:payments_attributes]
+    end
+
+    def sisow_payment_method?(payment_method)
+      payment_method.is_a?(PaymentMethod::SisowBilling::SisowPaymentMethod)
     end
   end
 end


### PR DESCRIPTION
When adding payment methods than the Sisow::Billing ones, controller failed.
The controller called a message on the billing_method that most don't
have. And that should not be called even if they have it.
This is in added filter
Hence we guard against this by checking for Sisow billing methods only.
